### PR TITLE
Prefix using custom map to asset

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -1,7 +1,13 @@
 import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
 
-// do not set to true in production!
-const DEBUG = true
+/**
+ * The DEBUG flag will do two things that help during development:
+ * 1. we will skip caching on the edge, which makes it easier to
+ *    debug.
+ * 2. we will return an error message on exception in your Response rather
+ *    than the default 404.html page.
+ */
+const DEBUG = false
 
 addEventListener('fetch', event => {
   try {
@@ -20,18 +26,14 @@ addEventListener('fetch', event => {
 
 async function handleEvent(event) {
   const url = new URL(event.request.url)
-    let options = {
-      // customize how incoming requests will map to assets
-      mapRequestToAsset: request => {
-        // compute the key used by default (e.g. / -> index.html)
-        let defaultAssetKey = mapRequestToAsset(request)
-        let url = new URL(defaultAssetKey.url)
-        // strip the prefix from looking up /docs for all files
-        url.pathname = url.pathname.replace(/^\/docs/, '/')
-        // inherit all other props from the default request
-        return new Request(url.toString(), defaultAssetKey)
-      },
-    }
+    let options = {}
+
+    /**
+     * You can add custom logic to how we fetch your assets
+     * by configuring the function `mapRequestToAsset`
+     */
+    // options.mapRequestToAsset = handlePrefix(/^\/docs/)
+
   try {
     if (DEBUG) {
       // customize caching
@@ -50,5 +52,26 @@ async function handleEvent(event) {
         status: 404,
       })
     }
+  }
+}
+
+/**
+ * Here's one example of how to modify a request to
+ * remove a specific prefix, in this case `/docs` from
+ * the url. This can be useful if you are deploying to a
+ * route on a zone, or if you only want your static content
+ * to exist at a specific path.
+ */
+function handlePrefix(prefix) {
+  return request => {
+    // compute the default (e.g. / -> index.html)
+    let defaultAssetKey = mapRequestToAsset(request)
+    let url = new URL(defaultAssetKey.url)
+
+    // strip the prefix from the path for lookup
+    url.pathname = url.pathname.replace(prefix, '/')
+    
+    // inherit all other props from the default request
+    return new Request(url.toString(), defaultAssetKey)
   }
 }

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -1,7 +1,4 @@
-import {
-  getAssetFromKV,
-  defaultRequestKeyModifier,
-} from '@cloudflare/kv-asset-handler'
+import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
 
 // do not set to true in production!
 const DEBUG = true
@@ -11,23 +8,31 @@ addEventListener('fetch', event => {
     event.respondWith(handleEvent(event))
   } catch (e) {
     if (DEBUG) {
-    return event.respondWith(new Response(e.message || e.toString(), {
-      status: 404,
-    }))
-  }
+      return event.respondWith(
+        new Response(e.message || e.toString(), {
+          status: 404,
+        }),
+      )
+    }
     event.respondWith(new Response('Internal Error', { status: 500 }))
   }
 })
 
+const myMapRequestToAsset = request => {
+  // start with the default map
+  let newRequest = mapRequestToAsset(request)
+  // strip the prefix from looking up all files
+  return new Request(newRequest.url.replace('/docs', ''), newRequest)
+}
 async function handleEvent(event) {
   const url = new URL(event.request.url)
   try {
-    let options = {}
+    let options = {
+      mapRequestToAsset: myMapRequestToAsset,
+    }
     if (DEBUG) {
-      options = {
-        cacheControl: {
-          bypassCache: true,
-        },
+      options.cacheControl = {
+        bypassCache: true,
       }
     }
     return await getAssetFromKV(event, options)
@@ -37,10 +42,9 @@ async function handleEvent(event) {
         status: 404,
       })
     } else {
-      return new Response(
-        `"${defaultRequestKeyModifier(event.request).url}" not found`,
-        { status: 404 },
-      )
+      return new Response(`"${mapRequestToAsset(url.pathname)}" not found`, {
+        status: 404,
+      })
     }
   }
 }

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -20,7 +20,6 @@ addEventListener('fetch', event => {
 
 async function handleEvent(event) {
   const url = new URL(event.request.url)
-  try {
     let options = {
       // customize how incoming requests will map to assets
       mapRequestToAsset: request => {
@@ -33,6 +32,7 @@ async function handleEvent(event) {
         return new Request(url.toString(), defaultAssetKey)
       },
     }
+  try {
     if (DEBUG) {
       // customize caching
       options.cacheControl = {
@@ -46,7 +46,7 @@ async function handleEvent(event) {
         status: 404,
       })
     } else {
-      return new Response(`"${mapRequestToAsset(url.pathname)}" not found`, {
+      return new Response(`"${options.mapRequestToAsset(event.request).url}" not found`, {
         status: 404,
       })
     }

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -26,13 +26,13 @@ addEventListener('fetch', event => {
 
 async function handleEvent(event) {
   const url = new URL(event.request.url)
-    let options = {}
+  let options = {}
 
-    /**
-     * You can add custom logic to how we fetch your assets
-     * by configuring the function `mapRequestToAsset`
-     */
-    // options.mapRequestToAsset = handlePrefix(/^\/docs/)
+  /**
+   * You can add custom logic to how we fetch your assets
+   * by configuring the function `mapRequestToAsset`
+   */
+  // options.mapRequestToAsset = handlePrefix(/^\/docs/)
 
   try {
     if (DEBUG) {
@@ -48,7 +48,11 @@ async function handleEvent(event) {
         status: 404,
       })
     } else {
-      return new Response(`"${options.mapRequestToAsset(event.request).url}" not found`, {
+      let requestedAsset = options.mapRequestToAsset
+        ? options.mapRequestToAsset(event.request).url
+        : mapRequestToAsset(event.request.url)
+
+      return new Response(`"${requestedAsset}" not found`, {
         status: 404,
       })
     }
@@ -70,7 +74,7 @@ function handlePrefix(prefix) {
 
     // strip the prefix from the path for lookup
     url.pathname = url.pathname.replace(prefix, '/')
-    
+
     // inherit all other props from the default request
     return new Request(url.toString(), defaultAssetKey)
   }


### PR DESCRIPTION
This PR does a couple of things:

1. we update our usage of the kv-asset-handler package based on the changes made in 0.0.4 (see this pr: https://github.com/cloudflare/kv-asset-handler/pull/29).
2. give explanations and examples for the `DEBUG` const and the `mapRequestToAsset` option.
3. for the `mapRequestToAsset` example, we show a very basic use case where a user wants to have all their requests go to, for example, `mysite.com/docs`. so, requests to `mysite.com/docs` will get routed to the `index.html` asset

also included are some prettier changes and an update to make sure that the debug response always returns what we want.