### PR TITLE
Alewis/serve 404

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -43,19 +43,24 @@ async function handleEvent(event) {
     }
     return await getAssetFromKV(event, options)
   } catch (e) {
-    if (DEBUG) {
-      return new Response(e.message || e.toString(), {
-        status: 404,
-      })
-    } else {
-      let requestedAsset = options.mapRequestToAsset
-        ? options.mapRequestToAsset(event.request).url
-        : mapRequestToAsset(event.request.url)
-
-      return new Response(`"${requestedAsset}" not found`, {
-        status: 404,
-      })
+    if (!DEBUG) {
+      try {
+        return await getAssetFromKV(event, {
+          mapRequestToAsset: notFoundAsset(),
+        })
+      } catch (e) {}
     }
+
+    return new Response(e.message || e.toString(), { status: 500 })
+  }
+}
+
+function notFoundAsset(assetName = '404.html') {
+  return request => {
+    const notFoundURL = new URL(request.url)
+    notFoundURL.pathname = assetName
+
+    return new Request(notFoundURL, { status: 404 })
   }
 }
 

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -43,6 +43,7 @@ async function handleEvent(event) {
     }
     return await getAssetFromKV(event, options)
   } catch (e) {
+    // if an error is thrown try to serve the asset at 404.html
     if (!DEBUG) {
       try {
         return await getAssetFromKV(event, {

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -47,7 +47,7 @@ async function handleEvent(event) {
     if (!DEBUG) {
       try {
         let notFoundResponse = await getAssetFromKV(event, {
-          mapRequestToAsset: notFoundAsset('404.html'),
+          mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/404.html`, req),
         })
 
         return new Response(notFoundResponse.body, { ...notFoundResponse, status: 404 })
@@ -55,15 +55,6 @@ async function handleEvent(event) {
     }
 
     return new Response(e.message || e.toString(), { status: 500 })
-  }
-}
-
-function notFoundAsset(assetName = '404.html') {
-  return request => {
-    const notFoundURL = new URL(request.url)
-    notFoundURL.pathname = assetName
-
-    return new Request(notFoundURL)
   }
 }
 

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -46,9 +46,11 @@ async function handleEvent(event) {
     // if an error is thrown try to serve the asset at 404.html
     if (!DEBUG) {
       try {
-        return await getAssetFromKV(event, {
-          mapRequestToAsset: notFoundAsset(),
+        let notFoundResponse = await getAssetFromKV(event, {
+          mapRequestToAsset: notFoundAsset('404.html'),
         })
+
+        return new Response(notFoundResponse.body, { ...notFoundResponse, status: 404 })
       } catch (e) {}
     }
 
@@ -61,7 +63,7 @@ function notFoundAsset(assetName = '404.html') {
     const notFoundURL = new URL(request.url)
     notFoundURL.pathname = assetName
 
-    return new Request(notFoundURL, { status: 404 })
+    return new Request(notFoundURL)
   }
 }
 


### PR DESCRIPTION
when the package can't find an asset it throws an error; this PR updates the template to serve the default 404.html asset we provide, giving users the ability to override this behavior.

Things I tested: 

- what happens when 404.html isn't present? it should not give back a 1101
- what happens when `DEBUG = true`?
- what happens when both of these things are true?