### PR TITLE
Set default security headers

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -48,6 +48,7 @@ async function handleEvent(event) {
     const response = new Response(page.body, page)
 
     response.headers.set('X-XSS-Protection', '1; mode=block')
+    response.headers.set('X-Content-Type-Options', 'nosniff')
     response.headers.set('X-Frame-Options', 'DENY')
     response.headers.set('Referrer-Policy', 'unsafe-url')
     response.headers.set('Feature-Policy', 'none')

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -41,7 +41,19 @@ async function handleEvent(event) {
         bypassCache: true,
       }
     }
-    return await getAssetFromKV(event, options)
+
+    const page = await getAssetFromKV(event, options)
+
+    // allow headers to be altered
+    const response = new Response(page.body, page)
+
+    response.headers.set('X-XSS-Protection', '1; mode=block')
+    response.headers.set('X-Frame-Options', 'DENY')
+    response.headers.set('Referrer-Policy', 'unsafe-url')
+    response.headers.set('Feature-Policy', 'none')
+
+    return response
+
   } catch (e) {
     // if an error is thrown try to serve the asset at 404.html
     if (!DEBUG) {


### PR DESCRIPTION
After releasing https://isbgpsafeyet.com some folks pointed out that it was scoring an F on https://securityheaders.com.

I’m no expert on this stuff but by request I’m back porting the additions @zackbloom made to [@cloudflare/isbgpsafeyet.com](https://github.com/cloudflare/isbgpsafeyet.com) (https://github.com/cloudflare/isbgpsafeyet.com/commit/261877b1385ead2ca73f98ec1816e3b189bfe0d7 and 
https://github.com/cloudflare/isbgpsafeyet.com/commit/ce806f6622fe5df7ad7eaf3277773b028431d53b) to improve the default security for future projects based on this template.