### PR TITLE
Updates kv-asset-handler to ~0.0.11

### DIFF
--- a/workers-site/package-lock.json
+++ b/workers-site/package-lock.json
@@ -4,23 +4,29 @@
   "requires": true,
   "dependencies": {
     "@cloudflare/kv-asset-handler": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.0.10.tgz",
-      "integrity": "sha512-PjxCUTb5tWixX54Igv6CFHmV2eJpwqTmaj0vQBMqWA2fsvoKaDHJJo1o0Hdy8Y3RAuBE/ka9cZe6rE0F/hN1eg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.0.11.tgz",
+      "integrity": "sha512-D2kGr8NF2Er//Mx0c4+8FtOHuLrnwOlpC48TbtyxRSegG/Js15OKoqxxlG9BMUj3V/YSqtN8bUU6pjaRlsoSqg==",
       "requires": {
-        "@types/mime": "^2.0.1",
-        "mime": "^2.4.4"
+        "@cloudflare/workers-types": "^2.0.0",
+        "@types/mime": "^2.0.2",
+        "mime": "^2.4.6"
       }
     },
+    "@cloudflare/workers-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.0.0.tgz",
+      "integrity": "sha512-SFUPQzR5aV2TBLP4Re+xNX5KfAGArcRGA44OLulBDnfblEf3J+6kFvdJAQwFhFpqru3wImwT1cX0wahk6EeWTw=="
+    },
     "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
+      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
     },
     "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
     }
   }
 }

--- a/workers-site/package.json
+++ b/workers-site/package.json
@@ -5,6 +5,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@cloudflare/kv-asset-handler": "^0.0.10"
+    "@cloudflare/kv-asset-handler": "~0.0.11"
   }
 }


### PR DESCRIPTION
caret only allows changes to the left-most non-zero value – so ^0.0.5
(which is what's in the repo) will only install version 0.0.5. 0.0.X
or ~0.0.11 will allow users to get patch updates
automatically.