### PR TITLE
Remove unused code

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -10,22 +10,10 @@ import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
 const DEBUG = false
 
 addEventListener('fetch', event => {
-  try {
-    event.respondWith(handleEvent(event))
-  } catch (e) {
-    if (DEBUG) {
-      return event.respondWith(
-        new Response(e.message || e.toString(), {
-          status: 500,
-        }),
-      )
-    }
-    event.respondWith(new Response('Internal Error', { status: 500 }))
-  }
+  event.respondWith(handleEvent(event))
 })
 
 async function handleEvent(event) {
-  const url = new URL(event.request.url)
   let options = {}
 
   /**


### PR DESCRIPTION
The error handling example does not work correctly because neither `handleEvent` nor `event.respondWith` ever throw. Since `handleEvent` already takes care of handling errors with its own try/catch, it makes sense to remove error handling from the caller.

The `url` variable also was never used.