### PR TITLE
Remove "Feature-Policy" header

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -39,7 +39,6 @@ async function handleEvent(event) {
     response.headers.set('X-Content-Type-Options', 'nosniff')
     response.headers.set('X-Frame-Options', 'DENY')
     response.headers.set('Referrer-Policy', 'unsafe-url')
-    response.headers.set('Feature-Policy', 'none')
 
     return response
 


### PR DESCRIPTION
Looks like the current syntax for the Feature-Policy header is wrong (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax)

Not sure if there are sensible default that would be correct here, but I would guess not.
Fixes issue #51 